### PR TITLE
Improve sigla extraction heuristics

### DIFF
--- a/cne_ml_extractor/utils.py
+++ b/cne_ml_extractor/utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import fitz, re
-from typing import List
+from typing import List, Optional
 
 def pdf_to_lines(pdf_path: str) -> list[list[str]]:
     pages = []
@@ -15,7 +15,34 @@ SEC_EFETIVOS  = re.compile(r"CANDIDAT[OA]S?\s+EFETIV[OA]S", re.I)
 SEC_SUPLENTES = re.compile(r"CANDIDAT[OA]S?\s+SUPLENTES",   re.I)
 LINE_NUM      = re.compile(r"^\s*(\d+)[\.\-ºo]?\s+(.+?)\s*$")
 
+_SIGLA_TOKEN = r"[A-ZÁÉÍÓÚÂÊÔÃÕÇ0-9]{2,}"
+_SIGLA_PART = rf"{_SIGLA_TOKEN}(?:[/-]{_SIGLA_TOKEN})*"
+_SIGLA_BEFORE_LISTA = re.compile(rf"\b({_SIGLA_PART})\b(?=\s*-\s*LISTA)", re.I)
+_SIGLA_BEFORE_HYPHEN = re.compile(rf"\b({_SIGLA_PART})\b(?=\s*-\s*)")
+_SIGLA_GENERIC = re.compile(rf"\b({_SIGLA_PART})\b")
+
 def normalize_quotes_dashes(s: str) -> str:
     return (s.replace("–","-").replace("—","-")
             .replace("’","'").replace("‘","'")
             .replace("“",'"').replace("”",'"'))
+
+def guess_sigla(line: str) -> Optional[str]:
+    """Heuristically extract a sigla from a list header line."""
+    upper_line = line.upper()
+
+    for pattern in (_SIGLA_BEFORE_LISTA, _SIGLA_BEFORE_HYPHEN):
+        m = pattern.search(upper_line)
+        if m:
+            return m.group(1)
+
+    stopwords = {"DE", "DA", "DO", "DAS", "DOS", "E", "LISTA", "LISTAS"}
+
+    for token in _SIGLA_GENERIC.findall(upper_line):
+        cleaned = token.strip(".,;:()[]{}")
+        if len(cleaned) < 2:
+            continue
+        if cleaned in stopwords:
+            continue
+        return cleaned
+
+    return None

--- a/ml/build_dataset.py
+++ b/ml/build_dataset.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
-import os, re, csv
-from cne_ml_extractor.utils import pdf_to_lines, SEC_EFETIVOS, SEC_SUPLENTES, LINE_NUM, normalize_quotes_dashes
+import os, csv
+from cne_ml_extractor.utils import (
+    pdf_to_lines,
+    SEC_EFETIVOS,
+    SEC_SUPLENTES,
+    LINE_NUM,
+    normalize_quotes_dashes,
+    guess_sigla,
+)
 
 IN_ROOT = './samples'
 OUT_DIR = './data'
 os.makedirs(os.path.join(OUT_DIR,'line_cls'), exist_ok=True)
 os.makedirs(os.path.join(OUT_DIR,'ner'), exist_ok=True)
-
-PARTY_HINT = re.compile(r"\b(PSD|CDS|PS|CHEGA|IL|VOLT|CDU|PAN|BLOCO|LIVRE|COLIGA|ALIAN[ÇC]A)\b", re.I)
 
 def main():
     line_csv = os.path.join(OUT_DIR, 'line_cls', 'all_lines.csv')
@@ -28,7 +33,8 @@ def main():
                         w_line.writerow([line,'SECAO']); continue
                     if SEC_SUPLENTES.search(line):
                         w_line.writerow([line,'SECAO']); continue
-                    if PARTY_HINT.search(line) and '-' in line:
+                    sigla_hint = guess_sigla(line)
+                    if sigla_hint and ("-" in line or "LISTA" in line.upper()):
                         w_line.writerow([line,'HEADER_LISTA']); continue
                     if LINE_NUM.match(line):
                         w_line.writerow([line,'CANDIDATO'])

--- a/tests/test_pipeline_ml.py
+++ b/tests/test_pipeline_ml.py
@@ -55,3 +55,79 @@ def test_process_pdf_to_csv_creates_output(tmp_path, monkeypatch, out_csv):
         "INDEPENDENTE",
     ]
     assert rows[1:] == []
+
+
+def test_process_pdf_to_csv_exports_candidates_with_generic_sigla(tmp_path, monkeypatch):
+    pages = [[
+        "XYZ - Lista de Cidadãos",
+        "1 João Silva",
+        "2 Maria Costa",
+    ]]
+
+    class DummyML:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def classify_line(self, line):
+            upper = line.upper()
+            if "LISTA" in upper:
+                return "HEADER_LISTA", 0.95
+            if pipeline_ml.LINE_NUM.match(line):
+                return "CANDIDATO", 0.95
+            return "OUTRO", 0.1
+
+        def extract_nome(self, line):
+            return line.split(" ", 1)[1]
+
+    monkeypatch.setattr(pipeline_ml, "pdf_to_lines", lambda path: pages)
+    monkeypatch.setattr(pipeline_ml, "MLExtractor", DummyML)
+
+    output_path = pipeline_ml.process_pdf_to_csv(
+        "dummy.pdf", "DTMNFR", str(tmp_path / "results.csv")
+    )
+
+    with Path(output_path).open(encoding="utf-8-sig", newline="") as f:
+        reader = csv.reader(f, delimiter=";")
+        rows = list(reader)
+
+    assert rows[1][3] == "XYZ"
+    assert rows[1][7] == "João Silva"
+    assert rows[2][3] == "XYZ"
+    assert rows[2][6] == "2"
+
+
+def test_process_pdf_to_csv_fallback_sigla_without_hyphen(tmp_path, monkeypatch):
+    pages = [[
+        "MOVIMENTO LIVRE LISTA UNICA",
+        "1 Ana Dias",
+    ]]
+
+    class DummyML:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def classify_line(self, line):
+            upper = line.upper()
+            if "LISTA" in upper:
+                return "HEADER_LISTA", 0.95
+            if pipeline_ml.LINE_NUM.match(line):
+                return "CANDIDATO", 0.95
+            return "OUTRO", 0.1
+
+        def extract_nome(self, line):
+            return line.split(" ", 1)[1]
+
+    monkeypatch.setattr(pipeline_ml, "pdf_to_lines", lambda path: pages)
+    monkeypatch.setattr(pipeline_ml, "MLExtractor", DummyML)
+
+    output_path = pipeline_ml.process_pdf_to_csv(
+        "dummy.pdf", "DTMNFR", str(tmp_path / "results.csv")
+    )
+
+    with Path(output_path).open(encoding="utf-8-sig", newline="") as f:
+        reader = csv.reader(f, delimiter=";")
+        rows = list(reader)
+
+    # Fallback should still assign a sigla so the candidate is exported
+    assert rows[1][3] == "MOVIMENTO"
+    assert rows[1][7] == "Ana Dias"


### PR DESCRIPTION
## Summary
- add a shared heuristic to extract party siglas from list headers
- update the pipeline and dataset builder to rely on the new heuristic and safer fallbacks
- extend pipeline tests to cover generic siglas and hyphen-less headers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e109345ba4832194265bbb486351e6