### PR TITLE
Handle orgao headers per line and cover mixed page case

### DIFF
--- a/cne_ml_extractor/pipeline_ml.py
+++ b/cne_ml_extractor/pipeline_ml.py
@@ -32,13 +32,17 @@ def process_pdf_to_csv(pdf_path: str, dtmnfr: str, out_csv: str,
     header = ["DTMNFR","ORGAO","TIPO","SIGLA","SIMBOLO","NOME_LISTA","NUM_ORDEM","NOME_CANDIDATO","PARTIDO_PROPONENTE","INDEPENDENTE"]
 
     for page_idx, lines in enumerate(pages):
-        joined = " \n ".join(lines).upper()
-        if re.search(r"\b2\.\s*C[ÂA]MARA\s+MUNICIPAL\b", joined, re.I):
-            orgao = "CM"
-
         for raw in lines:
             line = normalize_quotes_dashes(raw.strip())
             if not line:
+                continue
+
+            upper_line = line.upper()
+            if re.search(r"\b1\.\s*ASSEMBLEIA\s+MUNICIPAL\b", upper_line, re.I):
+                orgao = "AM"
+                continue
+            if re.search(r"\b2\.\s*C[ÂA]MARA\s+MUNICIPAL\b", upper_line, re.I):
+                orgao = "CM"
                 continue
             lbl, prob = ml.classify_line(line)
 

--- a/tests/test_pipeline_ml.py
+++ b/tests/test_pipeline_ml.py
@@ -131,3 +131,46 @@ def test_process_pdf_to_csv_fallback_sigla_without_hyphen(tmp_path, monkeypatch)
     # Fallback should still assign a sigla so the candidate is exported
     assert rows[1][3] == "MOVIMENTO"
     assert rows[1][7] == "Ana Dias"
+
+
+def test_process_pdf_to_csv_handles_mixed_orgao_pages(tmp_path, monkeypatch):
+    pages = [[
+        "1. Assembleia Municipal",
+        "LISTA AM - Partido X",
+        "1 João Silva",
+        "2 Maria Costa",
+        "2. Câmara Municipal",
+        "LISTA CM - Partido Y",
+        "1 Carlos Gomes",
+    ]]
+
+    class DummyML:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def classify_line(self, line):
+            upper = line.upper()
+            if "LISTA" in upper:
+                return "HEADER_LISTA", 0.95
+            if pipeline_ml.LINE_NUM.match(line):
+                return "CANDIDATO", 0.95
+            return "OUTRO", 0.1
+
+        def extract_nome(self, line):
+            return line.split(" ", 1)[1]
+
+    monkeypatch.setattr(pipeline_ml, "pdf_to_lines", lambda path: pages)
+    monkeypatch.setattr(pipeline_ml, "MLExtractor", DummyML)
+
+    output_path = pipeline_ml.process_pdf_to_csv(
+        "dummy.pdf", "DTMNFR", str(tmp_path / "results.csv")
+    )
+
+    with Path(output_path).open(encoding="utf-8-sig", newline="") as f:
+        reader = csv.reader(f, delimiter=";")
+        rows = list(reader)
+
+    assert rows[1][1] == "AM"
+    assert rows[2][1] == "AM"
+    assert rows[3][1] == "CM"
+    assert rows[3][7] == "Carlos Gomes"


### PR DESCRIPTION
## Summary
- update the ML pipeline to detect Assembleia/Câmara headers within the line loop and only switch the orgão for subsequent lines
- add a regression test covering pages with both Assembleia Municipal content and Câmara Municipal headers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e10b6c94348321a4ada11515f3d816