### PR TITLE
Update PowerShell wrapper to use python -c script

### DIFF
--- a/scripts/run_infer.ps1
+++ b/scripts/run_infer.ps1
@@ -1,17 +1,22 @@
 param(
-  [string]$Pdf   = ".\samples\Odivelas\input\edital.pdf",
+  [string]$Pdf   = ".\samples\editais\input\1116_Odivelas_AM e CM 28637.pdf",
   [string]$Dtmnfr= "111600",
-  [string]$OutDir= ".\samples\Odivelas\output"
+  [string]$OutDir= ".\samples\editais\output"
 )
 
 $ErrorActionPreference = "Stop"
 New-Item -Force -ItemType Directory $OutDir | Out-Null
 
 $CsvOut = Join-Path $OutDir "infer_AM_CM_final.csv"
-python - <<PY
+$script = @'
+import sys
 from cne_ml_extractor.pipeline_ml import process_pdf_to_csv
-csv_path = process_pdf_to_csv(r"""$Pdf""", dtmnfr=r"""$Dtmnfr""", out_csv=r"""$CsvOut""")
+
+pdf, dtmnfr, csv_out = sys.argv[1:4]
+csv_path = process_pdf_to_csv(pdf, dtmnfr=dtmnfr, out_csv=csv_out)
 print("CSV:", csv_path)
-PY
+'@
+
+python -c $script -- "$Pdf" "$Dtmnfr" "$CsvOut"
 
 Write-Host "✅ CSV em $CsvOut"


### PR DESCRIPTION
## Summary
- invoke the inference pipeline in PowerShell using a here-string and `python -c` so it runs on Windows without relying on a Bash here-doc
- keep the parameterized PDF, dtmnfr, and output directory handling while pointing the defaults to the bundled Odivelas sample

## Testing
- ⚠️ `powershell -NoLogo -File scripts/run_infer.ps1` *(PowerShell is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e1570a377c8321b823761e7c60cb0b