### PR TITLE
Fix run_infer PowerShell quoting and exit handling

### DIFF
--- a/scripts/run_infer.ps1
+++ b/scripts/run_infer.ps1
@@ -14,9 +14,13 @@ from cne_ml_extractor.pipeline_ml import process_pdf_to_csv
 
 pdf, dtmnfr, csv_out = sys.argv[1:4]
 csv_path = process_pdf_to_csv(pdf, dtmnfr=dtmnfr, out_csv=csv_out)
-print("CSV:", csv_path)
+print('CSV:', csv_path)
 '@
 
 python -c $script -- "$Pdf" "$Dtmnfr" "$CsvOut"
+
+if ($LASTEXITCODE -ne 0) {
+  throw "Python retornou o código de saída $LASTEXITCODE"
+}
 
 Write-Host "✅ CSV em $CsvOut"


### PR DESCRIPTION
## Summary
- adjust the inline Python snippet in run_infer.ps1 to avoid double-quote escaping issues on Windows
- ensure the script throws if the Python process fails

## Testing
- not run (PowerShell unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68e159a22e34832194e3d5f5c61cfdfb