### PR TITLE
Prevent directory traversal in webapp server

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,37 @@
+from http import HTTPStatus
+from http.client import HTTPConnection
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+from threading import Thread
+from time import sleep
+import sys
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+import pytest
+
+from webapp.server import ExtractHandler
+
+
+@pytest.fixture(name="http_server")
+def fixture_http_server():
+    server = ThreadingHTTPServer(("127.0.0.1", 0), ExtractHandler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    # Give the server a moment to start
+    sleep(0.1)
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        thread.join()
+
+
+def test_directory_traversal_is_rejected(http_server):
+    conn = HTTPConnection("127.0.0.1", http_server.server_port)
+    conn.request("GET", "/../../etc/passwd")
+    response = conn.getresponse()
+    assert response.status == HTTPStatus.NOT_FOUND
+    conn.close()

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>CNE ML Extractor</title>
+  </head>
+  <body>
+    <h1>CNE ML Extractor</h1>
+    <p>Static assets served by <code>webapp.server</code>.</p>
+  </body>
+</html>

--- a/webapp/server.py
+++ b/webapp/server.py
@@ -1,0 +1,70 @@
+"""Development web server for the extractor front-end."""
+from __future__ import annotations
+
+from http import HTTPStatus
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path, PurePosixPath
+from urllib.parse import unquote, urlsplit
+
+BASE_DIR = Path(__file__).resolve().parent
+INDEX_FILE = BASE_DIR / "index.html"
+
+
+class ExtractHandler(SimpleHTTPRequestHandler):
+    """Serve static assets from :data:`BASE_DIR` safely."""
+
+    def translate_path(self, path: str) -> str:  # type: ignore[override]
+        """Resolve the request path against :data:`BASE_DIR` securely.
+
+        The default implementation from :class:`SimpleHTTPRequestHandler`
+        performs the resolution using plain string manipulation which can lead
+        to directory traversal vulnerabilities.  We instead normalise the
+        request using :class:`pathlib` utilities and explicitly verify that the
+        resolved path stays under :data:`BASE_DIR`.
+        """
+
+        parsed_path = urlsplit(path).path
+        pure_path = PurePosixPath(unquote(parsed_path))
+
+        resolved_path = BASE_DIR
+        for part in pure_path.parts:
+            if part in ("", "/"):
+                continue
+            resolved_path /= part
+
+        resolved_path = resolved_path.resolve()
+
+        try:
+            resolved_path.relative_to(BASE_DIR)
+        except ValueError as exc:  # pragma: no cover - documented for clarity
+            raise PermissionError("Attempted access outside of BASE_DIR") from exc
+
+        if resolved_path.is_dir():
+            index_candidate = resolved_path / INDEX_FILE.name
+            if index_candidate.exists():
+                return str(index_candidate)
+
+        return str(resolved_path)
+
+    def send_head(self):  # type: ignore[override]
+        try:
+            return super().send_head()
+        except PermissionError:
+            self.send_error(HTTPStatus.NOT_FOUND, "File not found")
+            return None
+
+
+def serve(host: str = "0.0.0.0", port: int = 8000) -> None:
+    """Start a threaded HTTP server for the web application."""
+
+    httpd = ThreadingHTTPServer((host, port), ExtractHandler)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:  # pragma: no cover - manual stop
+        pass
+    finally:
+        httpd.server_close()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    serve()


### PR DESCRIPTION
## Summary
- add a lightweight webapp package with a hardened `ExtractHandler.translate_path`
- ensure requests resolving outside of the static directory return a 404 response
- cover the regression with a pytest exercising a traversal attempt

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e16623d0988321801c6a3f986b1709