### PR TITLE
Harden static file path resolution

### DIFF
--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -35,3 +35,11 @@ def test_directory_traversal_is_rejected(http_server):
     response = conn.getresponse()
     assert response.status == HTTPStatus.NOT_FOUND
     conn.close()
+
+
+def test_repository_file_is_not_exposed(http_server):
+    conn = HTTPConnection("127.0.0.1", http_server.server_port)
+    conn.request("GET", "/../../README.md")
+    response = conn.getresponse()
+    assert response.status == HTTPStatus.NOT_FOUND
+    conn.close()

--- a/webapp/server.py
+++ b/webapp/server.py
@@ -26,18 +26,18 @@ class ExtractHandler(SimpleHTTPRequestHandler):
         parsed_path = urlsplit(path).path
         pure_path = PurePosixPath(unquote(parsed_path))
 
-        try:
-            # Strip any leading slash to avoid ``Path`` treating the join as
-            # absolute. ``relative_to`` is only attempted when the path is
-            # rooted to keep compatibility with plain relative requests.
+        if pure_path.is_absolute():
+            # ``PurePosixPath.relative_to`` will drop the leading slash without
+            # normalising ``..`` segments, allowing :meth:`Path.resolve` to
+            # perform the final canonicalisation step.
             pure_path = pure_path.relative_to("/")
-        except ValueError:
-            pass
 
         resolved_path = (BASE_DIR / pure_path).resolve()
 
-        if not resolved_path.is_relative_to(BASE_DIR):
-            raise PermissionError("Attempted access outside of BASE_DIR")
+        try:
+            resolved_path.relative_to(BASE_DIR)
+        except ValueError as exc:
+            raise PermissionError("Attempted access outside of BASE_DIR") from exc
 
         if resolved_path.is_dir():
             index_candidate = resolved_path / INDEX_FILE.name


### PR DESCRIPTION
## Summary
- harden `ExtractHandler.translate_path` to resolve targets safely and reject paths that escape `BASE_DIR`
- add a regression test ensuring attempts to fetch `README.md` via traversal return `404`

## Testing
- pytest tests/test_webapp.py

------
https://chatgpt.com/codex/tasks/task_b_68e176e2ba5c832196fd41096171c47a